### PR TITLE
Format numbers with extra decimal places to the max of 2 decimal places, and reduce numbers that don't need the accuracy.

### DIFF
--- a/web/src/components/graph/FactoryNode.vue
+++ b/web/src/components/graph/FactoryNode.vue
@@ -25,7 +25,7 @@
               />
               <v-chip class="sf-chip">
                 <game-asset :subject="input.outputPart ?? 'unknown'" type="item" />
-                <span class="ml-2">{{ getPartDisplayName(input.outputPart) }}: {{ input.amount }}/min</span>
+                <span class="ml-2">{{ getPartDisplayName(input.outputPart) }}: {{ formatNumber(input.amount) }}/min</span>
               </v-chip>
             </div>
           </v-col>
@@ -42,7 +42,7 @@
             >
               <v-chip class="sf-chip">
                 <game-asset :subject="product.id" type="item" />
-                <span class="ml-2">{{ getPartDisplayName(product.id) }}: {{ product.amount }}/min</span>
+                <span class="ml-2">{{ getPartDisplayName(product.id) }}: {{ formatNumber(product.amount) }}/min</span>
               </v-chip>
             </div>
           </v-col>
@@ -59,7 +59,7 @@
             >
               <v-chip class="sf-chip">
                 <game-asset :subject="part.toString() ?? 'unknown'" type="item" />
-                <span class="ml-2">{{ getPartDisplayName(part) }}: {{ product.amount }}/min</span>
+                <span class="ml-2">{{ getPartDisplayName(part) }}: {{ formatNumber(product.amount) }}/min</span>
               </v-chip>
               <Handle
                 :id="`${data.factory.id}-${part}`"
@@ -80,6 +80,7 @@
   import { Handle } from '@vue-flow/core'
   import { CustomData } from '@/utils/graphUtils'
   import { getPartDisplayName } from '@/utils/helpers'
+  import { formatNumber } from '@/utils/numberFormatter'
 
   // props were passed from the slot using `v-bind="customNodeProps"`
   const props = defineProps<NodeProps<CustomData>>()

--- a/web/src/components/planner/PlannerFactory.vue
+++ b/web/src/components/planner/PlannerFactory.vue
@@ -111,13 +111,13 @@
                   />
                 </span>
                 <span>
-                  <b>{{ getPartDisplayName(part.id) }}</b>: {{ part.amount }}/min
+                  <b>{{ getPartDisplayName(part.id) }}</b>: {{ formatNumber(part.amount) }}/min
                 </span>
                 <span
                   v-if="hasMetricsForPart(factory, part.id) && factory.dependencies.metrics[part.id].difference !== 0"
                   class="ml-2"
                   :class="differenceClass(factory.dependencies.metrics[part.id].difference)"
-                >({{ factory.dependencies.metrics[part.id].difference }}/min)</span>
+                >({{ formatNumber(factory.dependencies.metrics[part.id].difference) }}/min)</span>
               </v-chip>
             </div>
           </v-row>
@@ -149,7 +149,7 @@
                     type="item"
                     width="32"
                   />
-                  <span class="ml-2"><b>{{ getPartDisplayName(part.part) }}:</b> {{ part.amount }}/min</span>
+                  <span class="ml-2"><b>{{ getPartDisplayName(part.part) }}:</b> {{ formatNumber(part.amount) }}/min</span>
                 </v-chip>
               </div>
             </div>
@@ -166,6 +166,7 @@
   import { Factory } from '@/interfaces/planner/FactoryInterface'
   import { DataInterface } from '@/interfaces/DataInterface'
   import { getPartDisplayName } from '@/utils/helpers'
+  import { formatNumber } from '@/utils/numberFormatter'
 
   const findFactory = inject('findFactory') as (id: string | number) => Factory
   const updateFactory = inject('updateFactory') as (factory: Factory) => void

--- a/web/src/components/planner/PlannerFactoryExportCalculator.vue
+++ b/web/src/components/planner/PlannerFactoryExportCalculator.vue
@@ -83,6 +83,7 @@
   }
 
   const calculateBelts = (amount: number, beltType: string) => {
+    // Simple math here to divide the amount by the belt's capacity
     let beltThroughput
 
     switch (beltType) {

--- a/web/src/components/planner/PlannerFactoryExportCalculator.vue
+++ b/web/src/components/planner/PlannerFactoryExportCalculator.vue
@@ -59,6 +59,7 @@
 
 <script setup lang="ts">
   import { defineProps } from 'vue'
+  import { formatNumber } from '@/utils/numberFormatter'
   import {
     ExportCalculatorFactorySettings,
     Factory,
@@ -82,8 +83,6 @@
   }
 
   const calculateBelts = (amount: number, beltType: string) => {
-    // Simple math here to divide the amount by the belt's capacity
-
     let beltThroughput
 
     switch (beltType) {
@@ -110,7 +109,7 @@
         break
     }
 
-    return (amount / beltThroughput).toFixed(1)
+    return formatNumber(amount / beltThroughput)
   }
 
   const beltDisplay = (belt: string) => {
@@ -140,7 +139,7 @@
     // Need amount per minute of the product, divided by the car capacity divided by the round trip time
     const carsNeeded = (amount / 60) / (carCap / rtt)
 
-    return carsNeeded.toFixed(2)
+    return formatNumber(carsNeeded)
   }
 
   const calculateFluidCars = () => {
@@ -155,7 +154,7 @@
     // Need amount per minute of the product, divided by the car capacity divided by the round trip time
     const carsNeeded = (amount / 60) / (carCap / rtt)
 
-    return carsNeeded.toFixed(2)
+    return formatNumber(carsNeeded)
   }
 
   const isFluid = (part: string) => {

--- a/web/src/components/planner/PlannerFactoryExports.vue
+++ b/web/src/components/planner/PlannerFactoryExports.vue
@@ -55,7 +55,7 @@
               <span>
                 <i class="fas fa-times" />
                 <span class="ml-2 font-weight-bold">
-                  Shortage of {{ getShortageAmount(factory, surplus.productId) }}/min
+                  Shortage of {{ formatNumber(getShortageAmount(factory, surplus.productId)) }}/min
                 </span>
                 <v-btn
                   class="ml-2"
@@ -89,7 +89,7 @@
               @click="changeCalculatorSelection(factory, request.factoryId, surplus.productId)"
             >
               <i class="fas fa-industry" />
-              <span class="ml-2"><b>{{ findFactory(request.factoryId).name }}</b>: {{ request.amount }}/min</span>
+              <span class="ml-2"><b>{{ findFactory(request.factoryId).name }}</b>: {{ formatNumber(request.amount) }}/min</span>
             </v-chip>
           </div>
         </v-col>

--- a/web/src/components/planner/PlannerFactoryExports.vue
+++ b/web/src/components/planner/PlannerFactoryExports.vue
@@ -69,10 +69,10 @@
           </div>
           <div class="ml-n1">
             <v-chip class="ma-1 mt-0">
-              <b>Surplus:</b>&nbsp;{{ factory.surplus[surplus.productId].amount }}/min
+              <b>Surplus:</b>&nbsp;{{ formatNumber(factory.surplus[surplus.productId].amount) }}/min
             </v-chip>
             <v-chip class="ma-1 mt-0">
-              <b>Demands:</b>&nbsp;{{ getRequestMetricsForFactoryByPart(factory, surplus.productId)?.request ?? 0 }}/min
+              <b>Demands:</b>&nbsp;{{ formatNumber(getRequestMetricsForFactoryByPart(factory, surplus.productId)?.request ?? 0) }}/min
             </v-chip>
           </div>
           <div
@@ -143,6 +143,7 @@
   } from '@/interfaces/planner/FactoryInterface'
   import { DataInterface } from '@/interfaces/DataInterface'
   import { getPartDisplayName } from '@/utils/helpers'
+  import { formatNumber } from '@/utils/numberFormatter'
 
   import PlannerFactoryExportCalculator from '@/components/planner/PlannerFactoryExportCalculator.vue'
   const findFactory = inject('findFactory') as (id: number) => Factory

--- a/web/src/components/planner/PlannerFactoryImports.vue
+++ b/web/src/components/planner/PlannerFactoryImports.vue
@@ -22,7 +22,7 @@
             >
               <game-asset :subject="resourceKey.toString() ?? 'unknown'" type="item" />
               <span class="ml-2">
-                <b>{{ getPartDisplayName(resourceKey.toString()) }}</b>: {{ resource.amount }}/min
+                <b>{{ getPartDisplayName(resourceKey.toString()) }}</b>: {{ formatNumber(resource.amount) }}/min
               </span>
             </v-chip>
           </div>
@@ -147,6 +147,7 @@
   import { Factory, FactoryInput, PartMetrics } from '@/interfaces/planner/FactoryInterface'
   import { addInputToFactory } from '@/utils/factory-management/inputs'
   import { getPartDisplayName } from '@/utils/helpers'
+  import { formatNumber } from '@/utils/numberFormatter'
 
   const findFactory = inject('findFactory') as (id: string | number) => Factory
   const updateFactory = inject('updateFactory') as (factory: Factory) => void

--- a/web/src/components/planner/PlannerFactoryProducts.vue
+++ b/web/src/components/planner/PlannerFactoryProducts.vue
@@ -106,7 +106,7 @@
         >
           <game-asset :subject="byProduct.id" type="item" />
           <span class="ml-2">
-            <b>{{ getPartDisplayName(byProduct.id) }}</b>: {{ byProduct.amount }}/min
+            <b>{{ getPartDisplayName(byProduct.id) }}</b>: {{ formatNumber(byProduct.amount) }}/min
           </span>
         </v-chip>
       </v-row>
@@ -123,7 +123,7 @@
         >
           <game-asset :subject="part.toString()" type="item" />
           <span class="ml-2">
-            <b>{{ getPartDisplayName(part.toString()) }}</b>: {{ requirement.amount.toFixed(1) }}/min
+            <b>{{ getPartDisplayName(part.toString()) }}</b>: {{ formatNumber(requirement.amount) }}/min
           </span>
         </v-chip>
         <div v-if="product.buildingRequirements.name" class="ml-0 text-body-1 d-inline">

--- a/web/src/components/planner/PlannerFactoryProducts.vue
+++ b/web/src/components/planner/PlannerFactoryProducts.vue
@@ -134,7 +134,7 @@
             >
               <game-asset :subject="product.buildingRequirements.name" type="building" />
               <span class="ml-2">
-                <b>{{ getBuildingDisplayName(product.buildingRequirements.name) }}</b>: {{ product.buildingRequirements.amount }}x
+                <b>{{ getBuildingDisplayName(product.buildingRequirements.name) }}</b>: {{ formatNumber(product.buildingRequirements.amount) }}x
               </span>
             </v-chip>
             <v-chip
@@ -143,7 +143,7 @@
             >
               <i class="fas fa-bolt" />
               <span class="ml-2">
-                {{ product.buildingRequirements.totalPower }} MW
+                {{ formatNumber(product.buildingRequirements.totalPower) }} MW
               </span>
             </v-chip>
           </span>
@@ -167,6 +167,7 @@
   import { DataInterface } from '@/interfaces/DataInterface'
   import { addProductToFactory } from '@/utils/factory-management/products'
   import { getPartDisplayName } from '@/utils/helpers'
+  import { formatNumber } from '@/utils/numberFormatter'
 
   const getBuildingDisplayName = inject('getBuildingDisplayName') as (part: string) => string
   const updateFactory = inject('updateFactory') as (factory: Factory) => void

--- a/web/src/components/planner/PlannerFactorySatisfaction.vue
+++ b/web/src/components/planner/PlannerFactorySatisfaction.vue
@@ -52,13 +52,13 @@
                 <p v-if="part.satisfied">
                   <v-icon icon="fas fa-check" />
                   <span class="ml-2">
-                    <b>{{ getPartDisplayName(partId) }}</b><br>{{ part.amountSupplied.toFixed(0) }}/{{ part.amountRequired.toFixed(0) }}/min
+                    <b>{{ getPartDisplayName(partId) }}</b><br>{{ part.amountSupplied.toFixed(0) }}/{{ formatNumber(part.amountRequired) }}/min
                   </span>
                 </p>
                 <p v-else>
                   <v-icon icon="fas fa-times" />
                   <span class="ml-2">
-                    <b>{{ getPartDisplayName(partId) }}</b><br>{{ part.amountSupplied.toFixed(0) }}/{{ part.amountRequired.toFixed(0) }} /min
+                    <b>{{ getPartDisplayName(partId) }}</b><br>{{ part.amountSupplied.toFixed(0) }}/{{ formatNumber(part.amountRequired) }} /min
                   </span>
                 </p>
               </v-col>

--- a/web/src/components/planner/PlannerFactorySatisfaction.vue
+++ b/web/src/components/planner/PlannerFactorySatisfaction.vue
@@ -127,7 +127,7 @@
             >
               <i class="fas fa-bolt" />
               <span class="ml-2">
-                {{ factory.totalPower }} MW
+                {{ formatNumber(factory.totalPower) }} MW
               </span>
             </v-chip>
           </v-card-text>
@@ -147,6 +147,7 @@
   import { computed, inject } from 'vue'
   import { addProductToFactory } from '@/utils/factory-management/products'
   import { getPartDisplayName } from '@/utils/helpers'
+  import { formatNumber } from '@/utils/numberFormatter'
 
   const getBuildingDisplayName = inject('getBuildingDisplayName') as (part: string) => string
   const updateFactory = inject('updateFactory') as (factory: Factory) => void

--- a/web/src/utils/numberFormatter.ts
+++ b/web/src/utils/numberFormatter.ts
@@ -1,10 +1,7 @@
-export function formatNumber(value: number): string {
-  if (Number.isInteger(value)) {
-    return value.toString();
-  } else {
-    // If the number is 2.25, show 2.25
-    // If the number is 2.50, show 2.5
-    // If the number is 2.333, show 2.33
-    return value.toFixed(value % 1 === 0 ? 1 : 2);
+export function formatNumber(value: any): string {
+  const num = Number(value);
+  if (isNaN(num)) {
+    throw new TypeError('The provided value is not a number');
   }
+  return num % 1 === 0 ? num.toFixed(0) : parseFloat(num.toFixed(2)).toString();
 }

--- a/web/src/utils/numberFormatter.ts
+++ b/web/src/utils/numberFormatter.ts
@@ -1,0 +1,7 @@
+export function formatNumber(value: number): string {
+  if (Number.isInteger(value)) {
+    return value.toString();
+  } else {
+    return value.toFixed(2);
+  }
+}

--- a/web/src/utils/numberFormatter.ts
+++ b/web/src/utils/numberFormatter.ts
@@ -2,6 +2,9 @@ export function formatNumber(value: number): string {
   if (Number.isInteger(value)) {
     return value.toString();
   } else {
-    return value.toFixed(2);
+    // If the number is 2.25, show 2.25
+    // If the number is 2.50, show 2.5
+    // If the number is 2.333, show 2.33
+    return value.toFixed(value % 1 === 0 ? 1 : 2);
   }
 }

--- a/web/src/utils/numberFormatter.ts
+++ b/web/src/utils/numberFormatter.ts
@@ -1,7 +1,9 @@
 export function formatNumber(value: any): string {
   const num = Number(value);
   if (isNaN(num)) {
-    throw new TypeError('The provided value is not a number');
+    //throw new TypeError('The provided value is not a number');
+    //Instead of an error - just return the value as is. This happens with the totalPower (todo: why is this a string and not a number?)
+    return value;
   }
   return num % 1 === 0 ? num.toFixed(0) : parseFloat(num.toFixed(2)).toString();
 }


### PR DESCRIPTION
This is an effort to format all of the numbers with the same formatting rules. Strip off zeros to 2 decimal places max.

Hopefully it's not controversial - I'm not great with vue, and had to hack a little to get there - I think the result is solid, but no hard feelings if this is not accepted. This partly addresses #10. 

- If the number is 2.0 or 2.00, show `2`
- If the number is 2.5 or 2.50, show `2.5`
- If the number is 2.25 or 2.250, show `2.25`
- If the number is 2.333, show `2.33`

<HR>

**Copilot generated description:**
This pull request focuses on improving the consistency and readability of numerical values displayed in various Vue components by introducing a new utility function, `formatNumber`, and applying it across multiple files. The most important changes include the addition of the `formatNumber` function, and its integration into several components to format numerical values.