### PR TITLE
Ensure power is a number throughout all code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "satisfactory-factories",
+  "version": "0.2.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "satisfactory-factories",
+      "version": "0.2.1",
+      "license": "AGPL-3.0-or-later"
+    }
+  }
+}

--- a/parsing/src/interfaces/Recipe.ts
+++ b/parsing/src/interfaces/Recipe.ts
@@ -12,7 +12,7 @@ export interface Recipe {
   products: RecipeItem[];
   building: {
     name: string;
-    power: string;
+    power: number;
   }
   isAlternate: boolean;
   isFicsmas: boolean;

--- a/parsing/src/processor.ts
+++ b/parsing/src/processor.ts
@@ -332,7 +332,7 @@ function getRecipes(
 // Create building object with the selected building and calculated power
             const building = {
                 name: selectedBuilding || '', // Use the first valid building, or empty string if none
-                power: String(powerPerBuilding || 0), // Use calculated power or 0
+                power: powerPerBuilding || 0, // Use calculated power or 0
             };
 
 


### PR DESCRIPTION
Fixes #59 

<HR>

Update `parsing/src/interfaces/Recipe.ts` and `parsing/src/processor.ts` to ensure `power` is a number.

* Change `power` type from `string` to `number` in the `Recipe` interface in `parsing/src/interfaces/Recipe.ts`.
* Change `power` type from `string` to `number` in the `building` object of the `Recipe` interface in `parsing/src/processor.ts`.
* Parse `power` as a number in the `getRecipes` function in `parsing/src/processor.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Maelstromeous/satisfactory-factories/pull/68?shareId=dd68e51f-cb9d-4a85-8b91-f0811672bf60).